### PR TITLE
New powerups, chain explosion and other bomb fixes/updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,6 +1206,35 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
+      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "homepage": "http://numanaral.github.io/bomberman",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ const config = {
 		movement: 200, // ms
 		bomb: {
 			firing: 2, // second
-			exploding: 2, // second
+			exploding: 1, // second
 		},
 	},
 	keyboardConfig: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ const config = {
 		blockDensity: 8 as RangeOf<10, 1>,
 		powerUpChance: 5 as RangeOf<5, 1>,
 		// Player defaults
-		lives: 1, // number
+		deathCount: 0, // number
 		[PowerUp.Life]: 1, // number
 		[PowerUp.BombCount]: 1, // number
 		[PowerUp.BombSize]: 1, // number

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,15 +13,21 @@ const config = {
 		powerUpChance: 5 as RangeOf<5, 1>,
 		// Player defaults
 		lives: 1, // number
+		[PowerUp.Life]: 1, // number
+		[PowerUp.BombCount]: 1, // number
 		[PowerUp.BombSize]: 1, // number
 		[PowerUp.MovementSpeed]: 200, // ms
 		powerUps: {
-			[PowerUp.BombSize]: 0,
-			[PowerUp.MovementSpeed]: 0,
+			[PowerUp.Life]: 0, // number
+			[PowerUp.BombCount]: 0, // number
+			[PowerUp.BombSize]: 0, // number
+			[PowerUp.MovementSpeed]: 0, // number
 		} as PowerUps,
 		powerUpIncreaseValue: {
-			[PowerUp.BombSize]: 1,
-			[PowerUp.MovementSpeed]: -50,
+			[PowerUp.Life]: 1, // number
+			[PowerUp.BombCount]: 1, // number
+			[PowerUp.BombSize]: 1, // number
+			[PowerUp.MovementSpeed]: -50, // ms
 		} as PowerUps,
 	},
 	size: {

--- a/src/containers/Game/GameContent.tsx
+++ b/src/containers/Game/GameContent.tsx
@@ -46,16 +46,23 @@ const GameContent = () => {
 					const {
 						[playerId]: keyboardConfig,
 					} = config.keyboardConfig.player;
+					const {
+						coordinates,
+						state: { lives },
+					} = playerConfig;
+
 					return (
-						<Character
-							id={playerId}
-							key={playerId}
-							name="Bomber"
-							coordinates={playerConfig.coordinates!}
-							keyboardConfig={keyboardConfig}
-							is3D={is3D}
-							ref={refFunc(playerConfig)}
-						/>
+						lives > 0 && (
+							<Character
+								id={playerId}
+								key={playerId}
+								name="Bomber"
+								coordinates={coordinates!}
+								keyboardConfig={keyboardConfig}
+								is3D={is3D}
+								ref={refFunc(playerConfig)}
+							/>
+						)
 					);
 				}
 			)}

--- a/src/containers/Game/GameContent.tsx
+++ b/src/containers/Game/GameContent.tsx
@@ -46,13 +46,15 @@ const GameContent = () => {
 					const {
 						[playerId]: keyboardConfig,
 					} = config.keyboardConfig.player;
-					const {
-						coordinates,
-						state: { lives },
-					} = playerConfig;
+					const { coordinates, state } = playerConfig;
+
+					const { deathCount } = state;
+
+					const isAlive =
+						deathCount < getPoweredUpValue(state, PowerUp.Life);
 
 					return (
-						lives > 0 && (
+						isAlive && (
 							<Character
 								id={playerId}
 								key={playerId}

--- a/src/containers/Game/components/PowerUp/PowerUp.tsx
+++ b/src/containers/Game/components/PowerUp/PowerUp.tsx
@@ -1,4 +1,5 @@
 import { PowerUp as PowerUpEnum } from 'enums';
+import icons from './icons';
 
 interface Props {
 	variant: PowerUpEnum;
@@ -8,6 +9,7 @@ interface Props {
 }
 
 const PowerUp = ({ variant, top, left, size }: Props) => {
+	const { icon: Icon, color } = icons[variant];
 	return (
 		<div
 			style={{
@@ -18,7 +20,7 @@ const PowerUp = ({ variant, top, left, size }: Props) => {
 				height: size,
 			}}
 		>
-			{variant}
+			<Icon color={color} />
 		</div>
 	);
 };

--- a/src/containers/Game/components/PowerUp/icons.tsx
+++ b/src/containers/Game/components/PowerUp/icons.tsx
@@ -1,0 +1,51 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+	faShoePrints,
+	faHeart,
+	faBomb,
+	faPrescriptionBottleAlt,
+} from '@fortawesome/free-solid-svg-icons';
+import { PowerUp } from 'enums';
+import theme from 'theme';
+
+type FontAwesomeIconProps = Omit<
+	React.ComponentProps<typeof FontAwesomeIcon>,
+	'icon'
+>;
+
+const ShoePrintsIcon = (props: FontAwesomeIconProps) => (
+	<FontAwesomeIcon icon={faShoePrints} {...props} />
+);
+const HeartIcon = (props: FontAwesomeIconProps) => (
+	<FontAwesomeIcon icon={faHeart} {...props} />
+);
+const BombIcon = (props: FontAwesomeIconProps) => (
+	<FontAwesomeIcon icon={faBomb} {...props} />
+);
+const PrescriptionBottleAltIcon = (props: FontAwesomeIconProps) => (
+	<FontAwesomeIcon icon={faPrescriptionBottleAlt} {...props} />
+);
+
+const icons: Record<
+	PowerUp,
+	{ icon: (props: FontAwesomeIconProps) => JSX.Element; color: string }
+> = {
+	[PowerUp.Life]: {
+		color: theme.palette.color.success,
+		icon: HeartIcon,
+	},
+	[PowerUp.BombCount]: {
+		color: theme.palette.color.error,
+		icon: BombIcon,
+	},
+	[PowerUp.BombSize]: {
+		color: theme.palette.color.warning,
+		icon: PrescriptionBottleAltIcon,
+	},
+	[PowerUp.MovementSpeed]: {
+		color: theme.palette.color.info,
+		icon: ShoePrintsIcon,
+	},
+};
+
+export default icons;

--- a/src/containers/Game/components/PowerUp/index.tsx
+++ b/src/containers/Game/components/PowerUp/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PowerUp';

--- a/src/containers/Game/types.ts
+++ b/src/containers/Game/types.ts
@@ -67,7 +67,7 @@ type PlayerRef = HTMLDivElement | null;
 type PowerUps = Record<PowerUp, number>;
 
 type PlayerState = {
-	lives: number;
+	deathCount: number;
 	[PowerUp.Life]: number;
 	[PowerUp.BombCount]: number;
 	[PowerUp.BombSize]: number;

--- a/src/containers/Game/types.ts
+++ b/src/containers/Game/types.ts
@@ -68,6 +68,8 @@ type PowerUps = Record<PowerUp, number>;
 
 type PlayerState = {
 	lives: number;
+	[PowerUp.Life]: number;
+	[PowerUp.BombCount]: number;
 	[PowerUp.BombSize]: number;
 	[PowerUp.MovementSpeed]: number;
 	/** How many power-ups have been collected */

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -33,9 +33,10 @@ enum Tile {
 }
 
 enum PowerUp {
-	BombSize = 'PU1',
-	MovementSpeed = 'PU2',
-	// Invincibility = 'PU3',
+	Life = 'PU1',
+	BombCount = 'PU2',
+	BombSize = 'PU3',
+	MovementSpeed = 'PU4',
 }
 
 enum Explosive {

--- a/src/store/redux/hooks/useGameProvider.tsx
+++ b/src/store/redux/hooks/useGameProvider.tsx
@@ -17,7 +17,7 @@ import {
 	triggerExplosionInGame,
 } from 'store/redux/reducers/game/actions';
 import {
-	BombId,
+	BombFn,
 	GameState,
 	OnMoveProps,
 	OnTriggerMove,
@@ -78,8 +78,8 @@ const useGameProvider = () => {
 		[dispatch]
 	);
 
-	const triggerExplosion = useCallback(
-		(bombId: BombId) => dispatch(triggerExplosionInGame(bombId)),
+	const triggerExplosion = useCallback<BombFn>(
+		(bombId, cb) => dispatch(triggerExplosionInGame(bombId, cb)),
 		[dispatch]
 	);
 

--- a/src/store/redux/reducers/game/actions.tsx
+++ b/src/store/redux/reducers/game/actions.tsx
@@ -52,9 +52,10 @@ const removeBombFromGame: GameActionFn = payload => ({
 	payload,
 });
 
-const triggerExplosionInGame: GameActionFn = payload => ({
+const triggerExplosionInGame: GameActionFn = (payload, cb) => ({
 	type: TRIGGER_EXPLOSION,
 	payload,
+	cb,
 });
 
 const onExplosionCompleteInGame: GameActionFn = payload => ({

--- a/src/store/redux/reducers/game/constants.tsx
+++ b/src/store/redux/reducers/game/constants.tsx
@@ -1,5 +1,6 @@
 // import { Immutable, castDraft } from 'immer';
 import config from 'config';
+import { Explosive } from 'enums';
 import { generateRandomGameMap, playerGenerator } from 'utils/game';
 import { GameState } from './types';
 
@@ -25,12 +26,15 @@ const DEFAULT_VALUES: GameState = {
 	animationCounter: 0,
 	powerUps: {},
 };
+
 const PLAYERS = {
 	P1,
 	P2,
 	P3,
 	P4,
 };
+
+const FIRE_VALUES = Object.values(Explosive).filter(v => v !== Explosive.Bomb);
 
 // Types
 const SET_GAME_STATE = `${KEY}/SET_GAME_STATE`;
@@ -53,6 +57,7 @@ const TOGGLE_GAME_NPC = `${KEY}/TOGGLE_GAME_NPC`;
 
 export {
 	PLAYERS,
+	FIRE_VALUES,
 	KEY,
 	DEFAULT_VALUES,
 	SET_GAME_STATE,

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -54,6 +54,7 @@ const gameReducer: Reducer<GameState, GameAction> = (
 	action
 ) => {
 	return produce(state, draft => {
+		// #region UTILITIES
 		const setSquare = (coordinates: Coordinates, newSquare: Square) => {
 			const {
 				xSquare,
@@ -157,6 +158,7 @@ const gameReducer: Reducer<GameState, GameAction> = (
 			}
 			draft.players[playerId]!.state.deathCount++;
 		};
+		// #endregion
 
 		switch (action.type) {
 			case SET_GAME_STATE:
@@ -395,7 +397,7 @@ const gameReducer: Reducer<GameState, GameAction> = (
 				});
 				break;
 			}
-			// GAME SETTINGS
+			// #region GAME SETTINGS
 			case TRIGGER_GAME_ANIMATION:
 				draft.animationCounter++;
 				break;
@@ -420,6 +422,7 @@ const gameReducer: Reducer<GameState, GameAction> = (
 				// draft.players = { ...draft.players, ...PLAYERS.P4 };
 				draft.players.P4 = castDraft(PLAYERS.P4);
 				break;
+			// #endregion
 			default:
 				// No default
 				break;

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -274,9 +274,15 @@ const gameReducer: Reducer<GameState, GameAction> = (
 					({ id }) => id === bombId
 				) as NonNullable<Bomb>;
 
+				// BUG: not sure why this happens, look into it further
+				if (!currentBomb) {
+					console.error('Bomb was not found', { state });
+					return;
+				}
+
 				const bombCoordinates = {
 					top: currentBomb.top,
-					left: currentBomb!.left,
+					left: currentBomb.left,
 				};
 
 				const bombSize = getBombSizeForPlayer(currentBomb.playerId);

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -247,6 +247,18 @@ const gameReducer: Reducer<GameState, GameAction> = (
 				if (isPlayerDead(playerId)) return;
 
 				const playerConfig = state.players[playerId]!;
+				const { coordinates } = playerConfig;
+				const {
+					xSquare,
+					ySquare,
+				} = getSquareCoordinatesFromSquareOrTopLeftCoordinates(
+					coordinates
+				);
+				// prevent double bomb in one spot
+				if (state.gameMap[ySquare][xSquare] === Explosive.Bomb) {
+					return;
+				}
+
 				const playerBombCountOnMap = state.bombs.filter(
 					({ playerId: pId }) => pId === playerId
 				).length;

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -116,6 +116,10 @@ const gameReducer: Reducer<GameState, GameAction> = (
 			return state.players[playerId]!.state;
 		};
 
+		const getLivesForPlayer = (playerId: PlayerId) => {
+			return getPoweredUpValue(getPlayerState(playerId), PowerUp.Life);
+		};
+
 		const getBombCountForPlayer = (playerId: PlayerId) => {
 			return getPoweredUpValue(
 				getPlayerState(playerId),
@@ -138,8 +142,10 @@ const gameReducer: Reducer<GameState, GameAction> = (
 		};
 
 		const isPlayerDead = (playerId: PlayerId) => {
+			const playerState = getPlayerState(playerId);
+			const { deathCount } = playerState;
 			// < 1 to prevent instant double explosion
-			return state.players[playerId]!.state.lives < 1;
+			return deathCount >= getPoweredUpValue(playerState, PowerUp.Life);
 		};
 
 		switch (action.type) {
@@ -307,14 +313,15 @@ const gameReducer: Reducer<GameState, GameAction> = (
 
 				// Take a life from the players
 				playersToKill.forEach(playerId => {
-					const { lives } = getPlayerState(playerId);
-					if (lives <= 1) {
+					const { deathCount } = getPlayerState(playerId);
+					// if next bomb is going to kill the player
+					if (deathCount >= getLivesForPlayer(playerId) - 1) {
 						setSquare(
 							state.players[playerId]!.coordinates,
 							Tile.Empty
 						);
 					}
-					draft.players[playerId]!.state.lives--;
+					draft.players[playerId]!.state.deathCount++;
 				});
 				break;
 			}

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -272,55 +272,41 @@ const gameReducer: Reducer<GameState, GameAction> = (
 			// set fire on all the coordinates
 			// this automatically "breaks" the breakable tiles
 			// URGENT: This will also contain two entity if Tile, Tile & Fire
-			horizontal.forEach(coordinates => {
-				// check if there is a tile and get a random power up or null
-				populatePowerUps(coordinates);
-				setSquare(coordinates, Explosive.FireHorizontal);
+			[
+				{
+					fireCoordinates: horizontal,
+					direction: Explosive.FireHorizontal,
+				},
+				{
+					fireCoordinates: vertical,
+					direction: Explosive.FireVertical,
+				},
+			].forEach(({ fireCoordinates, direction }) => {
+				fireCoordinates.forEach(coordinates => {
+					// check if there is a tile and get a random power up or null
+					populatePowerUps(coordinates);
+					setSquare(coordinates, direction);
 
-				// subtract a life from the players if they are hit
-				handlePlayerExplosionHit(coordinates);
+					// subtract a life from the players if they are hit
+					handlePlayerExplosionHit(coordinates);
 
-				const currentBombId = currentBomb.id;
-				// if there are bombs caught in fire, explode them
-				const bombToTrigger = getBombToTriggerFromExplosion(
-					coordinates,
-					currentBombId
-				);
-				if (bombToTrigger) {
-					const _explosionToComplete = triggerExplosion(
-						bombToTrigger.id,
-						[...bombsToSkip, currentBombId]
+					const currentBombId = currentBomb.id;
+					// if there are bombs caught in fire, explode them
+					const bombToTrigger = getBombToTriggerFromExplosion(
+						coordinates,
+						currentBombId
 					);
-					_explosionToComplete.forEach(bId =>
-						explosionToComplete.add(bId)
-					);
-					explosionToComplete.add(bombToTrigger.id);
-				}
-			});
-			vertical.forEach(coordinates => {
-				// check if there is a tile and get a random power up or null
-				populatePowerUps(coordinates);
-				setSquare(coordinates, Explosive.FireVertical);
-
-				// subtract a life from the players if they are hit
-				handlePlayerExplosionHit(coordinates);
-
-				const currentBombId = currentBomb.id;
-				// if there are bombs caught in fire, explode them
-				const bombToTrigger = getBombToTriggerFromExplosion(
-					coordinates,
-					currentBombId
-				);
-				if (bombToTrigger) {
-					const _explosionToComplete = triggerExplosion(
-						bombToTrigger.id,
-						[...bombsToSkip, currentBombId]
-					);
-					_explosionToComplete.forEach(bId =>
-						explosionToComplete.add(bId)
-					);
-					explosionToComplete.add(bombToTrigger.id);
-				}
+					if (bombToTrigger) {
+						const _explosionToComplete = triggerExplosion(
+							bombToTrigger.id,
+							[...bombsToSkip, currentBombId]
+						);
+						_explosionToComplete.forEach(bId =>
+							explosionToComplete.add(bId)
+						);
+						explosionToComplete.add(bombToTrigger.id);
+					}
+				});
 			});
 
 			// Core will not have an explosion direction

--- a/src/store/redux/reducers/game/reducer.tsx
+++ b/src/store/redux/reducers/game/reducer.tsx
@@ -116,6 +116,13 @@ const gameReducer: Reducer<GameState, GameAction> = (
 			return state.players[playerId]!.state;
 		};
 
+		const getBombCountForPlayer = (playerId: PlayerId) => {
+			return getPoweredUpValue(
+				getPlayerState(playerId),
+				PowerUp.BombCount
+			);
+		};
+
 		const getBombSizeForPlayer = (playerId: PlayerId) => {
 			return getPoweredUpValue(
 				getPlayerState(playerId),
@@ -232,9 +239,19 @@ const gameReducer: Reducer<GameState, GameAction> = (
 			case DROP_BOMB: {
 				const playerId = action.payload as PlayerId;
 				if (isPlayerDead(playerId)) return;
+
 				const playerConfig = state.players[playerId]!;
+				const playerBombCountOnMap = state.bombs.filter(
+					({ playerId: pId }) => pId === playerId
+				).length;
+				// ??!!: is >= possible? will > suffice?
+				// don't put more bombs than what you have
+				if (playerBombCountOnMap >= getBombCountForPlayer(playerId)) {
+					return;
+				}
 				const bomb = generateBomb(playerConfig);
 				draft.bombs.push(bomb);
+
 				// URGENT: This block will contain both the player and the bomb
 				// TODO: Figure out a proper way to handle this for NPC
 				setSquare(playerConfig.coordinates, Explosive.Bomb);

--- a/src/store/redux/reducers/game/types.ts
+++ b/src/store/redux/reducers/game/types.ts
@@ -26,7 +26,7 @@ type Bomb = {
 	explosionSize: number;
 } & TopLeftCoordinates;
 
-type BombFn = (bombId: BombId) => void;
+type BombFn = (bombId: BombId, cb?: CallableFunction) => void;
 
 /** Square coordinates that can break tiles and kill players. */
 type BombExplosionSquareCoordinates = Array<SquareCoordinates>;
@@ -62,13 +62,14 @@ type GamePayload =
 type GameAction = {
 	type: ValuesOf<typeof actionTypes>;
 	payload?: GamePayload;
+	cb?: CallableFunction;
 };
 
 type BombId = string;
 
 type OnExplosionComplete = (bombId: BombId) => void;
 
-type GameActionFn = (payload?: GamePayload) => void;
+type GameActionFn = (payload?: GamePayload, cb?: CallableFunction) => void;
 
 /** Triggers a move */
 type OnPrepareMoveProps = {

--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -243,7 +243,7 @@ const getExplosionScaleSize = (explosionSize: number) => {
 };
 
 type TilesToBreak = Array<SquareCoordinates>;
-type PlayersToKill = Array<PlayerId>;
+type PlayersToKill = Set<PlayerId>;
 enum ExplosionDirection {
 	HORIZONTAL = 'horizontal',
 	VERTICAL = 'vertical',
@@ -271,14 +271,14 @@ const getPlayersToKill = (
 	ySquare: number,
 	xSquare: number
 ) => {
-	const playersToKill: PlayersToKill = [];
+	const playersToKill: PlayersToKill = new Set();
 	Object.values<PlayerConfig>(players).forEach(({ id, coordinates }) => {
 		const {
 			xSquare: playerXSquare,
 			ySquare: playerYSquare,
 		} = topLeftCoordinatesToSquareCoordinates(coordinates);
 		if (playerXSquare === xSquare && playerYSquare === ySquare) {
-			playersToKill.push(id);
+			playersToKill.add(id);
 		}
 	});
 
@@ -461,8 +461,8 @@ const getExplosionResults = (
 	/** only returns fire locations */
 	checkOnlyFire = false
 ) => {
-	let tilesToBreak: TilesToBreak = [];
-	let playersToKill: PlayersToKill = [];
+	const tilesToBreak: TilesToBreak = [];
+	const playersToKill: PlayersToKill = new Set();
 	const coordinatesToSetOnFire: CoordinatesToSetOnFire = {
 		[ExplosionDirection.HORIZONTAL]: [],
 		[ExplosionDirection.VERTICAL]: [],
@@ -483,14 +483,12 @@ const getExplosionResults = (
 						xSquare,
 						ySquare,
 					});
-					tilesToBreak = [
-						...tilesToBreak,
-						...getTilesToBreak(gameMap, ySquare, xSquare),
-					];
-					playersToKill = [
-						...playersToKill,
-						...getPlayersToKill(players, ySquare, xSquare),
-					];
+					getTilesToBreak(gameMap, ySquare, xSquare).forEach(v => {
+						tilesToBreak.push(v);
+					});
+					getPlayersToKill(players, ySquare, xSquare).forEach(v => {
+						playersToKill.add(v);
+					});
 				}
 			);
 		}


### PR DESCRIPTION
- Fixed player death crash: Closes #36
- Don't replace player death Tile with Empty: Closes #35
- Chain explosion: Closes #31
- Added new PowerUps
  - Life: Closes #32
  - BombCount: Closes #30
  - Also resolves #3